### PR TITLE
Fix: Declare Webpack entry point constants for TypeScript

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -7,6 +7,9 @@ declare global {
     }
 }
 
+declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
+declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string;
+
 // This line is needed to make it a module.
 export {};
 


### PR DESCRIPTION
This commit resolves TypeScript compilation errors (TS2304) in `main.ts` by providing global type declarations for `MAIN_WINDOW_WEBPACK_ENTRY` and `MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY`.

These constants are injected by Electron Forge's Webpack plugin at runtime, but TypeScript requires them to be declared at compile time. The declarations have been added to `global.d.ts`.

This fix allows the TypeScript compilation step in `yarn dev` to pass, enabling the application to build and run with the previously implemented fixes for the blank screen issue and screenshot functionality.