### PR TITLE
Fix: Properly integrate webpack and resolve runtime errors

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -40,5 +40,32 @@ module.exports = {
       [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
       [FuseV1Options.OnlyLoadAppFromAsar]: true,
     }),
+    {
+      name: '@electron-forge/plugin-webpack',
+      config: {
+        mainConfig: undefined, // Rely on Forge's default main process webpack config
+        renderer: {
+          config: undefined, // Rely on Forge's default renderer process webpack config
+          entryPoints: [
+            {
+              html: './index.html',
+              js: './renderer.tsx',
+              name: 'main_window',
+              preload: {
+                js: './preload.ts'
+              }
+            },
+            {
+              html: './selector.html',
+              js: './selectorRenderer.ts',
+              name: 'selector_window',
+              preload: {
+                js: './selectorPreload.ts'
+              }
+            }
+          ]
+        }
+      }
+    }
   ],
 };

--- a/global.d.ts
+++ b/global.d.ts
@@ -7,9 +7,6 @@ declare global {
     }
 }
 
-declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
-declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string;
-
 // This line is needed to make it a module.
 export {};
 
@@ -21,3 +18,8 @@ declare global {
         }
     }
 }
+
+declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
+declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string;
+declare const SELECTOR_WINDOW_WEBPACK_ENTRY: string;
+declare const SELECTOR_WINDOW_PRELOAD_WEBPACK_ENTRY: string;

--- a/main.ts
+++ b/main.ts
@@ -190,7 +190,7 @@ async function initiateScreenshotSelectionProcess(event?: Electron.IpcMainEvent)
       transparent: true,
       alwaysOnTop: true,
       webPreferences: {
-        preload: path.join(__dirname, 'selectorPreload.js'),
+        preload: SELECTOR_WINDOW_PRELOAD_WEBPACK_ENTRY,
         contextIsolation: true,
         nodeIntegration: false,
       },
@@ -199,7 +199,7 @@ async function initiateScreenshotSelectionProcess(event?: Electron.IpcMainEvent)
 
     const backgroundImageDataUrl = fullScreenShotImage!.toDataURL();
     if (selectorWindow) {
-      selectorWindow.loadFile(path.join(__dirname, 'selector.html'));
+      selectorWindow.loadURL(SELECTOR_WINDOW_WEBPACK_ENTRY);
 
       selectorWindow.webContents.on('did-finish-load', () => {
           if (selectorWindow) {

--- a/package.json
+++ b/package.json
@@ -2,17 +2,17 @@
   "name": "app",
   "version": "1.0.0",
   "description": "桌面截图应用",
-  "main": "dist/main.js",
+  "main": ".webpack/main/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "copy-html": "cp *.html dist/ || echo \"No HTML files to copy at root\"",
     "build": "npm run copy-html && tsc",
-    "start": "npm run build && electron-forge start",
+    "start": "electron-forge start",
     "package": "npm run build && electron-forge package",
     "make": "npm run build && electron-forge make",
     "dev-server": "tsc -w",
     "dev-electron": "electron-forge start",
-    "dev": "npm run copy-html && tsc && concurrently \"npm run dev-server\" \"npm run dev-electron\""
+    "dev": "electron-forge start"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This commit comprehensively overhauls the project's build and Electron Forge configuration to correctly use the @electron-forge/plugin-webpack. This addresses previous TypeScript compilation errors and runtime ReferenceErrors related to WEBPACK_ENTRY constants.

Key changes:
- Configured `@electron-forge/plugin-webpack` in `forge.config.js` with explicit entry points for `main_window` (index.html, renderer.tsx, preload.ts) and `selector_window` (selector.html, selectorRenderer.ts, selectorPreload.ts).
- Updated `package.json` to set the "main" field to ".webpack/main/index.js", ensuring Electron runs the webpack-processed main process code.
- Simplified "dev" and "start" scripts in `package.json` to "electron-forge start", relying on the webpack plugin for the build and watch process.
- Modified `main.ts` to use `MAIN_WINDOW_WEBPACK_ENTRY`, `MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY`, `SELECTOR_WINDOW_WEBPACK_ENTRY`, and `SELECTOR_WINDOW_PRELOAD_WEBPACK_ENTRY` for loading window resources, ensuring they are sourced from webpack's output.
- Added global TypeScript declarations in `global.d.ts` for all `*_WEBPACK_ENTRY` constants to resolve TS2304 errors.
- The fix to `selector.html` (adding script tag for selectorRenderer.js) is now implicitly handled by the webpack plugin injecting scripts into its processed HTML output.

These changes should result in a successful `yarn dev` build, a functional application without a blank screen, and working screenshot capabilities.